### PR TITLE
fixed tags design removing funky absolute positioning

### DIFF
--- a/pages/addjob/addjob.wxml
+++ b/pages/addjob/addjob.wxml
@@ -81,8 +81,7 @@
         <view class="label-1" wx:for="{{checkboxItems}}">
           <label>
             <checkbox hidden value="{{item.name}}" checked="{{item.checked}}"></checkbox>
-            <view class="label-1__icon">
-            <view class="label-1__icon-checked" style="opacity:{{item.checked ? 1: 0}}"></view>
+            <view class="label-1__shape" style="background:{{item.checked ? '#8FBAF3': 'white'}}">
               <text class="label-1__text">{{item.value}}</text>
             </view>
           </label>

--- a/pages/addjob/addjob.wxss
+++ b/pages/addjob/addjob.wxss
@@ -58,46 +58,27 @@ textarea {
 
 
 .label-1{
-    margin: 10rpx 10rpx;
-    width: 180rpx;
-
+  margin: 5rpx;
+  width: auto;
 }
 .label-1__text{
-    /* display: inline-block; */
-    position: absolute;
-    top: 10rpx;
-    bottom: 10rpx;
-    left: 5rpx;
-    right: 5rpx;
-    text-align: center;
-    line-height: 30rpx;
-    font-size: 30rpx;
-    font-size: 28rpx;
-    font-family: Roboto;
-    font-weight: lighter;
-    fill-opacity: 40rpx;
-    
-    /* vertical-align: middle; */
+  /* display: inline-block; */
+  text-align: center;
+  line-height: 30rpx;
+  font-size: 30rpx;
+  font-size: 28rpx;
+  font-family: Roboto;
+  font-weight: lighter;
+  fill-opacity: 40rpx;
 }
 
-.label-1__icon {
-    position: relative;
-    margin-right: 20rpx;
-     /* display: inline-block;  */
-    vertical-align: middle;
-    width: 180rpx;
-    height: 50rpx;
-    background: white;
-    border: 2px solid #8FBAF3;
-    border-radius: 12px;
-}
-
-.label-1__icon-checked {
-    position: absolute;
-    width: 180rpx;
-    height: 50rpx;
-    background: #8FBAF3;
-    border-radius: 8px;
+.label-1__shape {
+  padding:0px 10px;
+  vertical-align: middle;
+  height: 50rpx;
+  background: white;
+  border: 2px solid #8FBAF3;
+  border-radius: 12px;
 }
 
 #container1{  


### PR DESCRIPTION
following up on an issue raised by @The-Pavel 

- tags were using a positioning absolute requiring a fixed width... not very flexible for text content
- the current "opacity switch" used to highlight the selected tag is a fun trick but this mechanism is more straightforward by changing the background of the parent instead